### PR TITLE
Remove redundant validation logic in explore schema to simplify the s…

### DIFF
--- a/server/src/schemas/lookml.ts
+++ b/server/src/schemas/lookml.ts
@@ -305,15 +305,7 @@ export const exploreSchema = parserValues.extend({
   join: z.record(z.string(), joinSchema).optional(),
   aggregate_table: z.record(z.string(), aggregateTableSchema).optional(),
   sql_always_where: z.string().optional(),
-}).strict().superRefine((val, ctx) => {
-  if (val.view_name && val.from) {
-      ctx.addIssue({
-        path: ['from', 'view_name'],
-        code: z.ZodIssueCode.custom,
-        message: 'view_name and from should not both be present. `from` on an explore is rarely used.',
-    });
-  }
-});
+}).strict();
 
 export const derivedTableSchema = z.object({
   cluster_keys: z.array(z.string()).optional(),


### PR DESCRIPTION
…tructure. The check for simultaneous presence of 'view_name' and 'from' has been eliminated.