### PR TITLE
Fix: Skip block LookML parser for dashboard files to avoid false error

### DIFF
--- a/server/src/models/workspace.ts
+++ b/server/src/models/workspace.ts
@@ -485,6 +485,12 @@ export class WorkspaceModel {
         // Remove existing data for this file
         this.clearDocumentData(uri);
 
+        // Dashboard files use YAML list syntax (- dashboard:), not block LookML.
+        // The lookml-parser expects block syntax and would report a false error on "-".
+        if (uri.includes(".dashboard.lookml")) {
+            return;
+        }
+
         const cleanUri = uri.replace(`file://${process.cwd()}/`, "");
         try {
             await this.parseDocument(document);


### PR DESCRIPTION
# Fix: Skip block LookML parser for dashboard files to avoid false error

## Problem

Opening or editing a `.dashboard.lookml` file causes the language server to report:

```
Expected "#", ":", or [ \t\n\r] but "-" found.  (Line 2)
```

LookML dashboard files use YAML list syntax (`- dashboard: name`). The server was passing their content to the block-style LookML parser (designed for `view:`, `explore:`, etc.), which does not accept a leading `-`, so it incorrectly reported a parse error.

## Solution

In `updateDocument()`, skip calling the LookML block parser when the document is a dashboard file (URI contains `.dashboard.lookml`). After clearing existing document data, return early so `parseDocument()` is never run for these files. No parse errors are stored or reported for dashboard files.

## Changes

- **`server/src/models/workspace.ts`**: In `updateDocument()`, after `clearDocumentData(uri)`, add a check for `.dashboard.lookml` in the URI and return without calling `parseDocument(document)`.

## Testing

1. Open a project that contains a `.dashboard.lookml` file (e.g. one starting with `---` and `- dashboard: ...`).
2. Open that dashboard file in the editor.
3. Before: error on line 2 ("Expected "#", ":", or [ \t\n\r] but "-" found.").
4. After: no error; dashboard file is ignored by the block parser as intended.

Fixes: https://github.com/lkrdev/lookml-language-server/issues/123
