### PR TITLE
feat: add field recognition in LookML dashboard files

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -186,7 +186,7 @@ export function activate(context: ExtensionContext) {
     documentSelector: [{ scheme: "file", language: "lookml" }],
     synchronize: {
       fileEvents: workspace.createFileSystemWatcher(
-        "**/*.{lkml,lookml,model.lkml,view.lkml,explore.lkml}",
+        "**/*.{lkml,lookml,model.lkml,view.lkml,explore.lkml,dashboard.lookml}",
       ),
     },
     outputChannel,

--- a/package.json
+++ b/package.json
@@ -76,7 +76,8 @@
                     ".lookml",
                     ".model.lkml",
                     ".view.lkml",
-                    ".explore.lkml"
+                    ".explore.lkml",
+                    ".dashboard.lookml"
                 ],
                 "configuration": "./client/language-configuration.json"
             }

--- a/server/src/models/dashboard-parser.ts
+++ b/server/src/models/dashboard-parser.ts
@@ -1,0 +1,317 @@
+import { TextDocument } from "vscode-languageserver-textdocument";
+import { Range } from "vscode-languageserver/node";
+import { getLines } from "../utils/document";
+
+export interface DashboardFieldReference {
+    viewName: string;
+    fieldName: string;
+    fullRef: string;
+    range: Range;
+    line: number;
+    context: "field" | "filter" | "listen" | "sort" | "pivots" | "column" | "dynamic_fields";
+}
+
+export interface DashboardExploreReference {
+    exploreName: string;
+    range: Range;
+    line: number;
+}
+
+export interface DashboardModelReference {
+    modelName: string;
+    range: Range;
+    line: number;
+}
+
+export interface DashboardInfo {
+    name: string;
+    title?: string;
+    fieldReferences: DashboardFieldReference[];
+    exploreReferences: DashboardExploreReference[];
+    modelReferences: DashboardModelReference[];
+}
+
+/**
+ * Parses LookML dashboard files (YAML-based) and extracts field references
+ * like `view_name.field_name` from fields, filters, listen, sorts, etc.
+ */
+export class DashboardParser {
+    /**
+     * Check if a document is a dashboard file
+     */
+    public static isDashboardFile(uri: string): boolean {
+        return uri.endsWith(".dashboard.lookml");
+    }
+
+    /**
+     * Parse a dashboard document and extract all field references.
+     * Uses line-by-line regex scanning for accurate position tracking
+     * (YAML parsers don't preserve original positions reliably).
+     */
+    public parseDashboard(document: TextDocument): DashboardInfo {
+        const lines = getLines(document);
+        const fieldReferences: DashboardFieldReference[] = [];
+        const exploreReferences: DashboardExploreReference[] = [];
+        const modelReferences: DashboardModelReference[] = [];
+        let dashboardName = "";
+        let dashboardTitle: string | undefined;
+
+        // view_name.field_name pattern — must contain a dot with word chars on both sides
+        const fieldRefPattern = /\b([a-zA-Z_][a-zA-Z0-9_]*)\.([a-zA-Z_][a-zA-Z0-9_]*)\b/g;
+
+        for (let i = 0; i < lines.length; i++) {
+            const line = lines[i];
+            const trimmed = line.trim();
+
+            // Extract dashboard name
+            if (trimmed.startsWith("- dashboard:")) {
+                const match = trimmed.match(/^- dashboard:\s+(\S+)/);
+                if (match) dashboardName = match[1];
+                continue;
+            }
+            if (trimmed.startsWith("title:") && !dashboardTitle) {
+                const match = trimmed.match(/^title:\s+["']?(.+?)["']?\s*$/);
+                if (match) dashboardTitle = match[1];
+                continue;
+            }
+
+            // Extract explore references
+            if (trimmed.startsWith("explore:")) {
+                const match = trimmed.match(/^explore:\s+(\S+)/);
+                if (match) {
+                    const exploreName = match[1];
+                    const col = line.indexOf(exploreName);
+                    exploreReferences.push({
+                        exploreName,
+                        range: Range.create(i, col, i, col + exploreName.length),
+                        line: i,
+                    });
+                }
+            }
+
+            // Extract model references
+            if (trimmed.startsWith("model:")) {
+                const match = trimmed.match(/^model:\s+(\S+)/);
+                if (match) {
+                    const modelName = match[1];
+                    const col = line.indexOf(modelName, line.indexOf("model:") + 6);
+                    modelReferences.push({
+                        modelName,
+                        range: Range.create(i, col, i, col + modelName.length),
+                        line: i,
+                    });
+                }
+            }
+
+            // Extract field: key in filters
+            if (trimmed.startsWith("field:")) {
+                const match = trimmed.match(/^field:\s+(\S+)/);
+                if (match) {
+                    const ref = match[1];
+                    const dotIdx = ref.indexOf(".");
+                    if (dotIdx > 0) {
+                        const viewName = ref.substring(0, dotIdx);
+                        const fieldName = ref.substring(dotIdx + 1);
+                        const col = line.indexOf(ref, line.indexOf("field:") + 6);
+                        fieldReferences.push({
+                            viewName,
+                            fieldName,
+                            fullRef: ref,
+                            range: Range.create(i, col, i, col + ref.length),
+                            line: i,
+                            context: "filter",
+                        });
+                    }
+                }
+                continue;
+            }
+
+            // Extract field references from list items (fields:, sorts:, pivots:, etc.)
+            if (trimmed.startsWith("- ")) {
+                const listContext = this.getListContext(lines, i);
+                if (listContext) {
+                    const itemContent = trimmed.substring(2).trim();
+                    // Strip sort suffixes like " desc" or " asc"
+                    const cleanItem = itemContent.replace(/\s+(asc|desc)\s*$/i, "");
+                    const dotIdx = cleanItem.indexOf(".");
+                    if (dotIdx > 0 && /^[a-zA-Z_][a-zA-Z0-9_]*\.[a-zA-Z_][a-zA-Z0-9_]*$/.test(cleanItem)) {
+                        const viewName = cleanItem.substring(0, dotIdx);
+                        const fieldName = cleanItem.substring(dotIdx + 1);
+                        const col = line.indexOf(cleanItem, line.indexOf("- ") + 2);
+                        fieldReferences.push({
+                            viewName,
+                            fieldName,
+                            fullRef: cleanItem,
+                            range: Range.create(i, col, i, col + cleanItem.length),
+                            line: i,
+                            context: listContext,
+                        });
+                    }
+                }
+                continue;
+            }
+
+            // Extract listen mappings: `filter_name: view_name.field_name`
+            if (this.isInListenBlock(lines, i)) {
+                const listenMatch = trimmed.match(/^(\S+):\s+(\S+)/);
+                if (listenMatch) {
+                    const ref = listenMatch[2];
+                    const dotIdx = ref.indexOf(".");
+                    if (dotIdx > 0 && /^[a-zA-Z_][a-zA-Z0-9_]*\.[a-zA-Z_][a-zA-Z0-9_]*$/.test(ref)) {
+                        const viewName = ref.substring(0, dotIdx);
+                        const fieldName = ref.substring(dotIdx + 1);
+                        const col = line.lastIndexOf(ref);
+                        fieldReferences.push({
+                            viewName,
+                            fieldName,
+                            fullRef: ref,
+                            range: Range.create(i, col, i, col + ref.length),
+                            line: i,
+                            context: "listen",
+                        });
+                    }
+                }
+            }
+        }
+
+        return {
+            name: dashboardName,
+            title: dashboardTitle,
+            fieldReferences,
+            exploreReferences,
+            modelReferences,
+        };
+    }
+
+    private static readonly FIELD_LIST_KEYS: Record<string, DashboardFieldReference["context"]> = {
+        "fields:": "field",
+        "sorts:": "sort",
+        "pivots:": "pivots",
+        "hidden_fields:": "field",
+        "dynamic_fields:": "dynamic_fields",
+    };
+
+    /**
+     * Scan upward from a list-item line to find its parent YAML key.
+     * Returns the field context if the parent is a known field-reference key,
+     * or null otherwise.
+     */
+    private getListContext(lines: string[], lineIdx: number): DashboardFieldReference["context"] | null {
+        const line = lines[lineIdx];
+        const currentIndent = line.length - line.trimStart().length;
+
+        for (let j = lineIdx - 1; j >= 0; j--) {
+            const prevLine = lines[j];
+            const prevTrimmed = prevLine.trim();
+            if (prevTrimmed === "") continue;
+
+            const prevIndent = prevLine.length - prevLine.trimStart().length;
+            if (prevIndent < currentIndent) {
+                for (const [key, ctx] of Object.entries(DashboardParser.FIELD_LIST_KEYS)) {
+                    if (prevTrimmed.startsWith(key)) return ctx;
+                }
+                return null;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Check if a line index is inside a `listen:` block by scanning upward.
+     */
+    private isInListenBlock(lines: string[], lineIdx: number): boolean {
+        // A listen value line looks like `      some_key: view.field`
+        // We need to find the parent `listen:` key
+        const line = lines[lineIdx];
+        const trimmed = line.trim();
+
+        // Must be a key: value pair (not a list item, not a known keyword)
+        if (trimmed.startsWith("- ") || trimmed.startsWith("#")) return false;
+        if (!trimmed.includes(":")) return false;
+
+        // Skip known YAML keys that are not listen mappings
+        const knownKeys = [
+            "name:", "title:", "type:", "model:", "explore:", "field:",
+            "default_value:", "allow_multiple_values:", "required:",
+            "ui_config:", "display:", "limit:", "height:", "width:",
+            "row:", "col:", "description:", "layout:", "preferred_viewer:",
+            "auto_run:", "note_text:", "note_display:", "note_state:",
+            "filters:", "fields:", "sorts:", "pivots:", "listen:",
+            "show_view_names:", "show_row_numbers:", "show_totals:",
+            "show_row_totals:", "value_format:", "dynamic_fields:",
+            "label:", "color_application:", "series_colors:",
+            "map_plot_mode:", "map_tile_provider:", "hidden_fields:",
+            "hidden_points_if_no:", "query_timezone:", "column_limit:",
+            "total:", "custom_color_enabled:", "value_labels:",
+            "label_type:", "show_x_axis_label:", "show_y_axis_labels:",
+            "y_axis_labels:", "x_axis_label:", "show_null_labels:",
+            "tags:", "stacking:", "series_types:", "truncate_column_names:",
+            "conditional_formatting:", "header_text_alignment:",
+            "comparison_type:", "comparison_reverse_colors:",
+            "show_comparison:", "show_comparison_label:", "comparison_label:",
+            "map_layer_name:", "single_value_title:", "value_format_name:",
+            "font_size:", "text_color:", "enable_conditional_formatting:",
+            "conditional_formatting_include_totals:",
+            "conditional_formatting_include_nulls:",
+        ];
+        for (const key of knownKeys) {
+            if (trimmed.startsWith(key)) return false;
+        }
+
+        // Scan upward to find the parent block
+        const currentIndent = line.length - line.trimStart().length;
+        for (let j = lineIdx - 1; j >= 0; j--) {
+            const prevLine = lines[j];
+            const prevTrimmed = prevLine.trim();
+            if (prevTrimmed === "") continue;
+
+            const prevIndent = prevLine.length - prevLine.trimStart().length;
+            if (prevIndent < currentIndent) {
+                return prevTrimmed.startsWith("listen:");
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Find the field reference at a given position in a dashboard document.
+     */
+    public getFieldReferenceAtPosition(
+        document: TextDocument,
+        line: number,
+        character: number,
+    ): DashboardFieldReference | undefined {
+        const info = this.parseDashboard(document);
+        for (const ref of info.fieldReferences) {
+            if (
+                ref.range.start.line === line &&
+                character >= ref.range.start.character &&
+                character <= ref.range.end.character
+            ) {
+                return ref;
+            }
+        }
+        return undefined;
+    }
+
+    /**
+     * Find the explore reference at a given position.
+     */
+    public getExploreReferenceAtPosition(
+        document: TextDocument,
+        line: number,
+        character: number,
+    ): DashboardExploreReference | undefined {
+        const info = this.parseDashboard(document);
+        for (const ref of info.exploreReferences) {
+            if (
+                ref.range.start.line === line &&
+                character >= ref.range.start.character &&
+                character <= ref.range.end.character
+            ) {
+                return ref;
+            }
+        }
+        return undefined;
+    }
+}

--- a/server/src/models/workspace.ts
+++ b/server/src/models/workspace.ts
@@ -27,6 +27,7 @@ import {
     DIMENSION_GROUP_DEFAULT_TIMEFRAMES,
 } from "../schemas/defaults";
 import { getLines } from "../utils/document";
+import { DashboardInfo, DashboardParser } from "./dashboard-parser";
 import { LookMLParser } from "./lookml-parser";
 
 
@@ -46,6 +47,10 @@ export class WorkspaceModel {
     private modelsByFile: Map<DocumentUri, string[]> = new Map();
     private loadedFiles: Set<string> = new Set();
 
+    // Dashboard tracking
+    private dashboardParser: DashboardParser = new DashboardParser();
+    private dashboards: Map<DocumentUri, DashboardInfo> = new Map();
+
     // Version tracking for incremental updates
     private documentVersions: Map<DocumentUri, number> = new Map();
 
@@ -56,6 +61,18 @@ export class WorkspaceModel {
 
     public getView(name: string): LookmlViewWithFileInfo | undefined {
         return this.views.get(name);
+    }
+
+    public getDashboardParser(): DashboardParser {
+        return this.dashboardParser;
+    }
+
+    public getDashboardInfo(uri: string): DashboardInfo | undefined {
+        return this.dashboards.get(uri);
+    }
+
+    public isDashboardFile(uri: string): boolean {
+        return DashboardParser.isDashboardFile(uri);
     }
 
     public getViews(): Map<string, LookmlViewWithFileInfo> {
@@ -485,9 +502,10 @@ export class WorkspaceModel {
         // Remove existing data for this file
         this.clearDocumentData(uri);
 
-        // Dashboard files use YAML list syntax (- dashboard:), not block LookML.
-        // The lookml-parser expects block syntax and would report a false error on "-".
+        // Dashboard files use YAML list syntax — parse them separately with the dashboard parser
         if (uri.includes(".dashboard.lookml")) {
+            const dashboardInfo = this.dashboardParser.parseDashboard(document);
+            this.dashboards.set(fsPath, dashboardInfo);
             return;
         }
 
@@ -531,6 +549,10 @@ export class WorkspaceModel {
      */
     private clearDocumentData(uri: DocumentUri): void {
         const fsPath = URI.parse(uri).fsPath;
+
+        // Remove dashboard data if present
+        this.dashboards.delete(fsPath);
+
         // Remove views defined in this file
         const viewNames = this.viewsByFile.get(fsPath) || [];
         for (const viewName of viewNames) {

--- a/server/src/providers/completion/completion-provider.ts
+++ b/server/src/providers/completion/completion-provider.ts
@@ -6,6 +6,7 @@ import {
   TextDocumentPositionParams,
 } from "vscode-languageserver/node";
 import * as z from "zod";
+import { DashboardParser } from "../../models/dashboard-parser";
 import { WorkspaceModel } from "../../models/workspace";
 import { splitIntoLines } from "../../utils/document";
 import { BlockCompletionProvider } from "./block-completions";
@@ -72,6 +73,11 @@ export class CompletionProvider {
     position: TextDocumentPositionParams,
   ): CompletionItem[] | CompletionList {
     try {
+      // Dashboard files get their own completion logic
+      if (DashboardParser.isDashboardFile(document.uri)) {
+        return this.getDashboardCompletions(document, position);
+      }
+
       // Detect context at current position
       const context = this.contextDetector.getContext(document, position);
       const lineContext = this.lineContextDetector.getLineContext(
@@ -250,5 +256,135 @@ export class CompletionProvider {
    */
   private isAtWordBoundary(text: string): boolean {
     return text.match(/\b\w+$/) !== null;
+  }
+
+  /**
+   * Provide completions for dashboard files.
+   * After `view_name.`, suggest fields from that view.
+   * On field-reference lines, suggest `view_name.field_name`.
+   */
+  private getDashboardCompletions(
+    document: TextDocument,
+    position: TextDocumentPositionParams,
+  ): CompletionList {
+    const lines = splitIntoLines(document.getText());
+    const line = lines[position.position.line] ?? "";
+    const textBefore = line.substring(0, position.position.character);
+    const items: CompletionItem[] = [];
+
+    // After a dot: suggest fields for the view before the dot
+    const dotMatch = textBefore.match(/\b([a-zA-Z_][a-zA-Z0-9_]*)\.([a-zA-Z_]?[a-zA-Z0-9_]*)$/);
+    if (dotMatch) {
+      const viewName = dotMatch[1];
+      const partial = dotMatch[2];
+      const viewDetails = this.workspaceModel.getView(viewName);
+      if (viewDetails) {
+        const fields = this.workspaceModel.getViewFields(viewDetails.view.$name!);
+        const allFields = [
+          ...Object.entries(fields.dimension || {}).map(([name, f]) => ({
+            name,
+            kind: "dimension" as const,
+            field: f,
+          })),
+          ...Object.entries(fields.measure || {}).map(([name, f]) => ({
+            name,
+            kind: "measure" as const,
+            field: f,
+          })),
+          ...Object.entries(fields.dimension_group || {}).map(([name, f]) => ({
+            name,
+            kind: "dimension_group" as const,
+            field: f,
+          })),
+        ];
+
+        for (const { name, kind, field } of allFields) {
+          if (partial && !name.startsWith(partial)) continue;
+          items.push({
+            label: name,
+            kind:
+              kind === "measure"
+                ? CompletionItemKind.Value
+                : CompletionItemKind.Field,
+            detail: `${kind} in ${viewName}`,
+            documentation: field?.description || field?.label || undefined,
+            insertText: name,
+          });
+        }
+      }
+
+      return { isIncomplete: false, items };
+    }
+
+    // If on a line that expects a field ref, offer view.field completions
+    const trimmed = line.trim();
+    const isFieldContext =
+      trimmed.startsWith("- ") ||
+      trimmed.startsWith("field:") ||
+      this.isDashboardListenLine(lines, position.position.line);
+
+    if (isFieldContext) {
+      const views = this.workspaceModel.getViews();
+      for (const [viewName, viewDetails] of views) {
+        if (viewName.startsWith("+")) continue;
+        const fields = this.workspaceModel.getViewFields(viewName);
+        for (const [fieldName, field] of Object.entries(fields.dimension || {})) {
+          items.push({
+            label: `${viewName}.${fieldName}`,
+            kind: CompletionItemKind.Field,
+            detail: "dimension",
+            documentation: (field as any)?.description || (field as any)?.label || undefined,
+          });
+        }
+        for (const [fieldName, field] of Object.entries(fields.measure || {})) {
+          items.push({
+            label: `${viewName}.${fieldName}`,
+            kind: CompletionItemKind.Value,
+            detail: "measure",
+            documentation: (field as any)?.description || (field as any)?.label || undefined,
+          });
+        }
+        for (const [fieldName, field] of Object.entries(fields.dimension_group || {})) {
+          items.push({
+            label: `${viewName}.${fieldName}`,
+            kind: CompletionItemKind.Field,
+            detail: "dimension_group",
+            documentation: (field as any)?.description || (field as any)?.label || undefined,
+          });
+        }
+      }
+    }
+
+    // On `explore:` lines, suggest explores
+    if (trimmed.startsWith("explore:") || trimmed === "explore:") {
+      for (const [exploreName] of this.workspaceModel.getExplores()) {
+        items.push({
+          label: exploreName,
+          kind: CompletionItemKind.Module,
+          detail: "explore",
+        });
+      }
+    }
+
+    return { isIncomplete: false, items };
+  }
+
+  private isDashboardListenLine(lines: string[], lineIdx: number): boolean {
+    const line = lines[lineIdx];
+    const trimmed = line.trim();
+    if (trimmed.startsWith("- ") || trimmed.startsWith("#")) return false;
+    if (!trimmed.includes(":")) return false;
+
+    const currentIndent = line.length - line.trimStart().length;
+    for (let j = lineIdx - 1; j >= 0; j--) {
+      const prevLine = lines[j];
+      const prevTrimmed = prevLine.trim();
+      if (prevTrimmed === "") continue;
+      const prevIndent = prevLine.length - prevLine.trimStart().length;
+      if (prevIndent < currentIndent) {
+        return prevTrimmed.startsWith("listen:");
+      }
+    }
+    return false;
   }
 }

--- a/server/src/providers/completion/completion-provider.ts
+++ b/server/src/providers/completion/completion-provider.ts
@@ -280,36 +280,22 @@ export class CompletionProvider {
       const viewDetails = this.workspaceModel.getView(viewName);
       if (viewDetails) {
         const fields = this.workspaceModel.getViewFields(viewDetails.view.$name!);
-        const allFields = [
-          ...Object.entries(fields.dimension || {}).map(([name, f]) => ({
-            name,
-            kind: "dimension" as const,
-            field: f,
-          })),
-          ...Object.entries(fields.measure || {}).map(([name, f]) => ({
-            name,
-            kind: "measure" as const,
-            field: f,
-          })),
-          ...Object.entries(fields.dimension_group || {}).map(([name, f]) => ({
-            name,
-            kind: "dimension_group" as const,
-            field: f,
-          })),
+        const fieldTypes = [
+          { type: "dimension", map: fields.dimension, kind: CompletionItemKind.Field },
+          { type: "measure", map: fields.measure, kind: CompletionItemKind.Value },
+          { type: "dimension_group", map: fields.dimension_group, kind: CompletionItemKind.Field },
         ];
-
-        for (const { name, kind, field } of allFields) {
-          if (partial && !name.startsWith(partial)) continue;
-          items.push({
-            label: name,
-            kind:
-              kind === "measure"
-                ? CompletionItemKind.Value
-                : CompletionItemKind.Field,
-            detail: `${kind} in ${viewName}`,
-            documentation: field?.description || field?.label || undefined,
-            insertText: name,
-          });
+        for (const { type, map, kind } of fieldTypes) {
+          for (const [name, field] of Object.entries(map || {})) {
+            if (partial && !name.startsWith(partial)) continue;
+            items.push({
+              label: name,
+              kind,
+              detail: `${type} in ${viewName}`,
+              documentation: (field as any)?.description || (field as any)?.label || undefined,
+              insertText: name,
+            });
+          }
         }
       }
 
@@ -328,29 +314,20 @@ export class CompletionProvider {
       for (const [viewName, viewDetails] of views) {
         if (viewName.startsWith("+")) continue;
         const fields = this.workspaceModel.getViewFields(viewName);
-        for (const [fieldName, field] of Object.entries(fields.dimension || {})) {
-          items.push({
-            label: `${viewName}.${fieldName}`,
-            kind: CompletionItemKind.Field,
-            detail: "dimension",
-            documentation: (field as any)?.description || (field as any)?.label || undefined,
-          });
-        }
-        for (const [fieldName, field] of Object.entries(fields.measure || {})) {
-          items.push({
-            label: `${viewName}.${fieldName}`,
-            kind: CompletionItemKind.Value,
-            detail: "measure",
-            documentation: (field as any)?.description || (field as any)?.label || undefined,
-          });
-        }
-        for (const [fieldName, field] of Object.entries(fields.dimension_group || {})) {
-          items.push({
-            label: `${viewName}.${fieldName}`,
-            kind: CompletionItemKind.Field,
-            detail: "dimension_group",
-            documentation: (field as any)?.description || (field as any)?.label || undefined,
-          });
+        const fieldTypes = [
+          { type: "dimension", map: fields.dimension, kind: CompletionItemKind.Field },
+          { type: "measure", map: fields.measure, kind: CompletionItemKind.Value },
+          { type: "dimension_group", map: fields.dimension_group, kind: CompletionItemKind.Field },
+        ];
+        for (const { type, map, kind } of fieldTypes) {
+          for (const [fieldName, field] of Object.entries(map || {})) {
+            items.push({
+              label: `${viewName}.${fieldName}`,
+              kind,
+              detail: type,
+              documentation: (field as any)?.description || (field as any)?.label || undefined,
+            });
+          }
         }
       }
     }

--- a/server/src/providers/definition.ts
+++ b/server/src/providers/definition.ts
@@ -1,4 +1,5 @@
 import { Definition, Position, TextDocument } from "vscode-languageserver/node";
+import { DashboardParser } from "../models/dashboard-parser";
 import { WorkspaceModel } from "../models/workspace";
 import { getLines } from "../utils/document";
 
@@ -140,12 +141,41 @@ export class DefinitionProvider {
   }
 
   /**
+   * Resolve a `view_name.field_name` reference to the field's definition location.
+   */
+  private resolveFieldReference(viewName: string, fieldName: string): Definition | undefined {
+    const viewDetails = this.workspaceModel.getView(viewName);
+    if (!viewDetails) return;
+
+    const fieldPosition =
+      viewDetails?.positions?.dimension?.[fieldName]?.$name?.$p ||
+      viewDetails?.positions?.measure?.[fieldName]?.$name?.$p ||
+      viewDetails?.positions?.dimension_group?.[fieldName]?.$name?.$p;
+
+    if (fieldPosition) {
+      return {
+        uri: viewDetails.uri,
+        range: {
+          start: { line: fieldPosition[0], character: fieldPosition[1] },
+          end: { line: fieldPosition[2], character: fieldPosition[3] },
+        },
+      };
+    }
+    return undefined;
+  }
+
+  /**
    * Provide definition locations for LookML elements
    */
   public getDefinition(
     document: TextDocument,
     position: Position,
   ): Definition | undefined {
+    // Handle dashboard files with the dashboard parser
+    if (DashboardParser.isDashboardFile(document.uri)) {
+      return this.getDashboardDefinition(document, position);
+    }
+
     const lines = getLines(document);
     const word = this.getWordAtPosition(document, position);
     if (!word) return;
@@ -162,31 +192,7 @@ export class DefinitionProvider {
     // If the word contains a dot and we're in a valid context, it's a field reference
     if (isBetweenBrackets && word.includes(".")) {
       const [viewName, fieldName] = word.split(".");
-      const viewDetails = this.workspaceModel.getView(viewName);
-
-      if (viewDetails) {
-        const fieldPosition =
-          viewDetails?.positions?.dimension?.[fieldName]?.$name?.$p ||
-          viewDetails?.positions?.measure?.[fieldName]?.$name?.$p ||
-          viewDetails?.positions?.dimension_group?.[fieldName]?.$name?.$p;
-
-        if (fieldPosition) {
-          return {
-            uri: viewDetails.uri,
-            range: {
-              start: {
-                line: fieldPosition[0],
-                character: fieldPosition[1],
-              },
-              end: {
-                line: fieldPosition[2],
-                character: fieldPosition[3],
-              },
-            },
-          };
-        }
-      }
-      return;
+      return this.resolveFieldReference(viewName, fieldName);
     }
 
     // If not a dotted reference, check if it's a view reference
@@ -217,5 +223,69 @@ export class DefinitionProvider {
         },
       },
     };
+  }
+
+  /**
+   * Handle go-to-definition in dashboard files.
+   */
+  private getDashboardDefinition(
+    document: TextDocument,
+    position: Position,
+  ): Definition | undefined {
+    const dashboardParser = this.workspaceModel.getDashboardParser();
+
+    // Check for field reference (view_name.field_name)
+    const fieldRef = dashboardParser.getFieldReferenceAtPosition(
+      document,
+      position.line,
+      position.character,
+    );
+    if (fieldRef) {
+      return this.resolveFieldReference(fieldRef.viewName, fieldRef.fieldName);
+    }
+
+    // Check for explore reference
+    const exploreRef = dashboardParser.getExploreReferenceAtPosition(
+      document,
+      position.line,
+      position.character,
+    );
+    if (exploreRef) {
+      const exploreDetails = this.workspaceModel.getExplore(exploreRef.exploreName);
+      if (exploreDetails?.positions?.$p) {
+        const p = exploreDetails.positions.$p;
+        return {
+          uri: exploreDetails.uri,
+          range: {
+            start: { line: p[0], character: p[1] },
+            end: { line: p[2], character: p[3] },
+          },
+        };
+      }
+    }
+
+    // Fallback: try to detect a bare view_name.field_name under the cursor
+    const word = this.getWordAtPosition(document, position);
+    if (word?.includes(".")) {
+      const [viewName, fieldName] = word.split(".");
+      return this.resolveFieldReference(viewName, fieldName);
+    }
+
+    // Try as a view name
+    if (word) {
+      const viewDetails = this.workspaceModel.getView(word);
+      if (viewDetails?.positions?.$name?.$p) {
+        const p = viewDetails.positions.$name.$p;
+        return {
+          uri: viewDetails.uri,
+          range: {
+            start: { line: p[0], character: p[1] },
+            end: { line: p[2], character: p[3] },
+          },
+        };
+      }
+    }
+
+    return undefined;
   }
 }

--- a/server/src/providers/diagnostics.ts
+++ b/server/src/providers/diagnostics.ts
@@ -16,6 +16,7 @@ import {
 } from "vscode-languageserver/node";
 import { URI } from "vscode-uri";
 import { ZodError, ZodIssue } from "zod";
+import { DashboardParser } from "../models/dashboard-parser";
 import { WorkspaceModel } from "../models/workspace";
 import { VALID_TIMEFRAMES } from "../schemas/constants";
 import { exploreSchema, LookMLView } from "../schemas/lookml";
@@ -75,6 +76,11 @@ export enum DiagnosticCode {
     EXPLORE_FIELD_NOT_FOUND = 70002,
     EXPLORE_VIEW_NOT_INCLUDED = 70003,
     EXPLORE_INVALID_EXTENDS = 70004,
+
+    // Dashboard validation (80000-89999)
+    DASHBOARD_VIEW_NOT_FOUND = 80001,
+    DASHBOARD_FIELD_NOT_FOUND = 80002,
+    DASHBOARD_EXPLORE_NOT_FOUND = 80003,
 }
 
 export class DiagnosticsProvider {
@@ -89,6 +95,11 @@ export class DiagnosticsProvider {
      * Validate a document and return diagnostics
      */
     public validateDocument(document: TextDocument): Diagnostic[] {
+        // Dashboard files get their own validation path
+        if (DashboardParser.isDashboardFile(document.uri)) {
+            return this.validateDashboard(document);
+        }
+
         this.fullyExplored.clear();
         const diagnostics: Diagnostic[] = [];
         diagnostics.push(...this.validateProperties(document));
@@ -1416,5 +1427,58 @@ export class DiagnosticsProvider {
             Position.create(startLine, startChar),
             Position.create(endLine, endChar),
         );
+    }
+
+    /**
+     * Validate field references in a dashboard file.
+     */
+    private validateDashboard(document: TextDocument): Diagnostic[] {
+        const diagnostics: Diagnostic[] = [];
+        const dashboardParser = this.workspaceModel.getDashboardParser();
+        const info = dashboardParser.parseDashboard(document);
+
+        for (const ref of info.fieldReferences) {
+            const viewDetails = this.workspaceModel.getView(ref.viewName);
+            if (!viewDetails) {
+                diagnostics.push({
+                    severity: DiagnosticSeverity.Warning,
+                    range: ref.range,
+                    message: `View "${ref.viewName}" not found`,
+                    source: "lookml-lsp",
+                    code: DiagnosticCode.DASHBOARD_VIEW_NOT_FOUND,
+                });
+                continue;
+            }
+
+            const fields = this.workspaceModel.getViewFields(viewDetails.view.$name!);
+            if (
+                !fields.dimension?.[ref.fieldName] &&
+                !fields.measure?.[ref.fieldName] &&
+                !fields.dimension_group?.[ref.fieldName]
+            ) {
+                diagnostics.push({
+                    severity: DiagnosticSeverity.Warning,
+                    range: ref.range,
+                    message: `Field "${ref.fieldName}" not found in view "${ref.viewName}"`,
+                    source: "lookml-lsp",
+                    code: DiagnosticCode.DASHBOARD_FIELD_NOT_FOUND,
+                });
+            }
+        }
+
+        for (const ref of info.exploreReferences) {
+            const exploreDetails = this.workspaceModel.getExplore(ref.exploreName);
+            if (!exploreDetails) {
+                diagnostics.push({
+                    severity: DiagnosticSeverity.Warning,
+                    range: ref.range,
+                    message: `Explore "${ref.exploreName}" not found`,
+                    source: "lookml-lsp",
+                    code: DiagnosticCode.DASHBOARD_EXPLORE_NOT_FOUND,
+                });
+            }
+        }
+
+        return diagnostics;
     }
 }

--- a/server/src/providers/hover.ts
+++ b/server/src/providers/hover.ts
@@ -6,6 +6,7 @@ import {
   Range,
   TextDocument,
 } from "vscode-languageserver/node";
+import { DashboardParser } from "../models/dashboard-parser";
 import { WorkspaceModel } from "../models/workspace";
 import { getLines } from "../utils/document";
 
@@ -79,7 +80,11 @@ export class HoverProvider {
     document: TextDocument,
     position: Position,
   ): Hover | null {
-    //const text = document.getText();
+    // Dashboard files: use the dashboard parser for precise field detection
+    if (DashboardParser.isDashboardFile(document.uri)) {
+      return this.getDashboardHover(document, position);
+    }
+
     const wordRange = this.getWordRangeAtPosition(document, position);
 
     if (!wordRange) {
@@ -433,5 +438,87 @@ export class HoverProvider {
     }
 
     return null;
+  }
+
+  /**
+   * Provide hover information for dashboard files.
+   */
+  private getDashboardHover(
+    document: TextDocument,
+    position: Position,
+  ): Hover | null {
+    const dashboardParser = this.workspaceModel.getDashboardParser();
+
+    // Check for field reference
+    const fieldRef = dashboardParser.getFieldReferenceAtPosition(
+      document,
+      position.line,
+      position.character,
+    );
+    if (fieldRef) {
+      const viewDetails = this.workspaceModel.getView(fieldRef.viewName);
+      if (!viewDetails) {
+        return {
+          contents: {
+            kind: MarkupKind.Markdown,
+            value: `**${fieldRef.fullRef}** — View \`${fieldRef.viewName}\` not found`,
+          },
+          range: fieldRef.range,
+        };
+      }
+
+      const fields = this.workspaceModel.getViewFields(viewDetails.view.$name!);
+      const field =
+        fields.dimension?.[fieldRef.fieldName] ||
+        fields.measure?.[fieldRef.fieldName] ||
+        fields.dimension_group?.[fieldRef.fieldName];
+
+      if (!field) {
+        return {
+          contents: {
+            kind: MarkupKind.Markdown,
+            value: `**${fieldRef.fullRef}** — Field \`${fieldRef.fieldName}\` not found in view \`${fieldRef.viewName}\``,
+          },
+          range: fieldRef.range,
+        };
+      }
+
+      const details: string[] = [];
+      if (field.type) details.push(`**Type:** \`${field.type}\``);
+      if (field.sql) details.push(`**SQL:** \`${field.sql}\``);
+      if (field.label) details.push(`**Label:** ${field.label}`);
+      if (field.description) details.push(`**Description:** ${field.description}`);
+
+      const fieldType = fields.dimension?.[fieldRef.fieldName]
+        ? "Dimension"
+        : fields.measure?.[fieldRef.fieldName]
+          ? "Measure"
+          : "Dimension Group";
+
+      return {
+        contents: {
+          kind: MarkupKind.Markdown,
+          value: `**${fieldRef.fullRef}** (${fieldType} in \`${fieldRef.viewName}\`)\n\n${details.join("\n\n")}`,
+        },
+        range: fieldRef.range,
+      };
+    }
+
+    // Check for explore reference
+    const exploreRef = dashboardParser.getExploreReferenceAtPosition(
+      document,
+      position.line,
+      position.character,
+    );
+    if (exploreRef) {
+      return this.getExploreHover(exploreRef.exploreName);
+    }
+
+    // Fallback to word-based hover
+    const wordRange = this.getWordRangeAtPosition(document, position);
+    if (!wordRange) return null;
+    const word = document.getText(wordRange);
+
+    return this.getViewHover(word) || this.getExploreHover(word) || null;
   }
 }


### PR DESCRIPTION
## Summary

Closes #129

Dashboard files (`.dashboard.lookml`) were previously ignored by the language server. This PR adds full LSP support for `view_name.field_name` references found in dashboard YAML:

- **Go-to-definition**: Ctrl+click on field refs (`view.field`), explore names, or view names in dashboards to jump to their LookML source.
- **Hover**: hover over field references to see type, SQL, label, and description from the underlying view definition.
- **Diagnostics**: warnings for unknown views, fields, or explores referenced in dashboard tiles, filters, `listen:` blocks, and sorts.
- **Completions**: after typing `view_name.`, get field suggestions from that view; on field-reference lines (`fields:`, `sorts:`, `listen:`, `field:`), get full `view.field` completions; on `explore:` lines, get explore name suggestions.

### Implementation details

- New `DashboardParser` class (`server/src/models/dashboard-parser.ts`) — a line-by-line regex scanner that extracts field, explore, and model references with accurate source positions. Uses upward-scanning heuristics to detect YAML context (`fields:`, `listen:`, `sorts:`, etc.).
- `WorkspaceModel.updateDocument()` now parses dashboard files on open/change instead of skipping them.
- `.dashboard.lookml` registered as a recognized language extension in `package.json` and included in the client file watcher glob.
- All four providers (definition, hover, diagnostics, completion) check `DashboardParser.isDashboardFile()` early and delegate to dashboard-specific logic.

### Files changed

| File | Change |
|------|--------|
| `package.json` | Add `.dashboard.lookml` to language extensions |
| `client/src/extension.ts` | Add `.dashboard.lookml` to file watcher glob |
| `server/src/models/dashboard-parser.ts` | **New** — dashboard YAML parser |
| `server/src/models/workspace.ts` | Parse dashboards instead of skipping; expose dashboard parser |
| `server/src/providers/definition.ts` | Add dashboard go-to-definition |
| `server/src/providers/hover.ts` | Add dashboard hover |
| `server/src/providers/diagnostics.ts` | Add dashboard field/view/explore validation |
| `server/src/providers/completion/completion-provider.ts` | Add dashboard field completions |

## Test plan

- [ ] Open a `.dashboard.lookml` file — verify it's recognized as LookML
- [ ] Ctrl+click on a `view_name.field_name` in `fields:`, `listen:`, `sorts:`, or `field:` — verify it jumps to the field definition
- [ ] Ctrl+click on an explore name — verify it jumps to the explore definition
- [ ] Hover over a field reference — verify tooltip shows type, SQL, label, description
- [ ] Type a wrong field name (e.g. `view.nonexistent`) — verify a warning diagnostic appears
- [ ] Type `view_name.` and trigger completions — verify fields from that view are suggested
- [ ] Type on a `- ` line under `fields:` and trigger completions — verify `view.field` suggestions

Made with [Cursor](https://cursor.com)