### PR TITLE
feat: detect multiple primary keys in a single view

### DIFF
--- a/server/src/__tests__/multiple_primary_keys/index.test.ts
+++ b/server/src/__tests__/multiple_primary_keys/index.test.ts
@@ -1,0 +1,98 @@
+import * as fs from "fs";
+import * as path from "path";
+import { TextDocument } from "vscode-languageserver-textdocument";
+import { Diagnostic } from "vscode-languageserver/node";
+import { WorkspaceModel } from "../../models/workspace";
+import {
+    DiagnosticCode,
+    DiagnosticsProvider,
+} from "../../providers/diagnostics";
+import { createMockConnection, getDiagnosticsForView } from "../utils";
+
+describe("Multiple Primary Keys", () => {
+    let workspaceModel: WorkspaceModel;
+    let diagnosticsProvider: DiagnosticsProvider;
+    let mockConnection: any;
+    let sharedDiagnostics: Diagnostic[];
+
+    beforeAll(async () => {
+        mockConnection = createMockConnection();
+        workspaceModel = new WorkspaceModel({ connection: mockConnection });
+        diagnosticsProvider = new DiagnosticsProvider(workspaceModel);
+
+        const examplePath = path.join(
+            __dirname,
+            "lkml",
+            "multiple_primary_keys.model.lkml",
+        );
+
+        const content = fs.readFileSync(examplePath, "utf8");
+        const document = TextDocument.create(
+            `file://${examplePath}`,
+            "lookml",
+            1,
+            content,
+        );
+
+        await workspaceModel.parseFiles({
+            source: examplePath,
+            reset: true,
+        });
+
+        sharedDiagnostics = diagnosticsProvider.validateDocument(document);
+    });
+
+    test("should report errors for view with two primary keys", () => {
+        const errors = getDiagnosticsForView(
+            workspaceModel,
+            sharedDiagnostics,
+            "two_pks",
+        );
+        const pkErrors = errors.filter(
+            (d) => d.code === DiagnosticCode.VIEW_MULTIPLE_PRIMARY_KEYS,
+        );
+        expect(pkErrors.length).toEqual(2);
+        expect(pkErrors[0].message).toContain("Multiple primary keys");
+        expect(pkErrors[0].message).toContain("pk1");
+        expect(pkErrors[0].message).toContain("pk2");
+    });
+
+    test("should not report errors for view with single primary key", () => {
+        const errors = getDiagnosticsForView(
+            workspaceModel,
+            sharedDiagnostics,
+            "single_pk",
+        );
+        const pkErrors = errors.filter(
+            (d) => d.code === DiagnosticCode.VIEW_MULTIPLE_PRIMARY_KEYS,
+        );
+        expect(pkErrors.length).toEqual(0);
+    });
+
+    test("should not report errors for view with no primary keys", () => {
+        const errors = getDiagnosticsForView(
+            workspaceModel,
+            sharedDiagnostics,
+            "no_pk",
+        );
+        const pkErrors = errors.filter(
+            (d) => d.code === DiagnosticCode.VIEW_MULTIPLE_PRIMARY_KEYS,
+        );
+        expect(pkErrors.length).toEqual(0);
+    });
+
+    test("should report error when child view adds a second PK inherited from base", () => {
+        const errors = getDiagnosticsForView(
+            workspaceModel,
+            sharedDiagnostics,
+            "child_adds_pk",
+        );
+        const pkErrors = errors.filter(
+            (d) => d.code === DiagnosticCode.VIEW_MULTIPLE_PRIMARY_KEYS,
+        );
+        expect(pkErrors.length).toEqual(1);
+        expect(pkErrors[0].message).toContain("Multiple primary keys");
+        expect(pkErrors[0].message).toContain("child_id");
+        expect(pkErrors[0].message).toContain("base_id");
+    });
+});

--- a/server/src/__tests__/multiple_primary_keys/lkml/multiple_primary_keys.model.lkml
+++ b/server/src/__tests__/multiple_primary_keys/lkml/multiple_primary_keys.model.lkml
@@ -1,0 +1,59 @@
+connection: "test"
+
+# View with two primary keys in the same view — should error
+view: two_pks {
+  dimension: pk1 {
+    primary_key: yes
+    sql: ${TABLE}.id1 ;;
+  }
+  dimension: pk2 {
+    primary_key: yes
+    sql: ${TABLE}.id2 ;;
+  }
+  dimension: normal_dim {
+    sql: ${TABLE}.name ;;
+  }
+}
+
+# View with exactly one primary key — should be fine
+view: single_pk {
+  dimension: id {
+    primary_key: yes
+    sql: ${TABLE}.id ;;
+  }
+  dimension: name {
+    sql: ${TABLE}.name ;;
+  }
+}
+
+# View with no primary keys — should be fine
+view: no_pk {
+  dimension: name {
+    sql: ${TABLE}.name ;;
+  }
+}
+
+# Base view with one PK, extended view adds another PK — should error on the child
+view: base_with_pk {
+  extension: required
+  dimension: base_id {
+    primary_key: yes
+    sql: ${TABLE}.base_id ;;
+  }
+  dimension: base_name {
+    sql: ${TABLE}.name ;;
+  }
+}
+
+view: child_adds_pk {
+  extends: [base_with_pk]
+  dimension: child_id {
+    primary_key: yes
+    sql: ${TABLE}.child_id ;;
+  }
+}
+
+explore: two_pks {}
+explore: single_pk {}
+explore: no_pk {}
+explore: child_adds_pk {}

--- a/server/src/providers/diagnostics.ts
+++ b/server/src/providers/diagnostics.ts
@@ -36,6 +36,7 @@ export enum DiagnosticCode {
     VIEW_REF_VIEW_NOT_FOUND = 20002,
     VIEW_REF_VIEW_NOT_INCLUDED = 20003,
     VIEW_REF_FIELD_IN_SQL = 20004,
+    VIEW_MULTIPLE_PRIMARY_KEYS = 20005,
 
     // SQL Reference validation (30000-39999)
     SQL_REF_FIELD_NOT_FOUND = 30001,
@@ -502,6 +503,61 @@ export class DiagnosticsProvider {
         return diagnostics;
     }
 
+    private validateMultiplePrimaryKeys(
+        view: LookmlView,
+        viewDetails: LookmlViewWithFileInfo,
+    ): Diagnostic[] {
+        const diagnostics: Diagnostic[] = [];
+        const positions = viewDetails.positions;
+
+        const allFields = this.workspaceModel.getViewFields(view.$name!);
+        const pkDimensions: { name: string; isLocal: boolean }[] = [];
+
+        for (const [dimName, dim] of Object.entries(allFields.dimension)) {
+            if (
+                dim &&
+                typeof dim === "object" &&
+                dim.primary_key === true
+            ) {
+                const isLocal = !!view.dimension?.[dimName];
+                pkDimensions.push({ name: dimName, isLocal });
+            }
+        }
+
+        if (pkDimensions.length <= 1) {
+            return diagnostics;
+        }
+
+        const pkNames = pkDimensions.map((pk) => pk.name).join(", ");
+        for (const pk of pkDimensions) {
+            if (!pk.isLocal) continue;
+            const dimPosition =
+                positions?.dimension?.[pk.name]?.primary_key;
+            const fallbackPosition = positions?.dimension?.[pk.name];
+            const pos = dimPosition || fallbackPosition;
+            if (pos?.$p) {
+                diagnostics.push({
+                    severity: DiagnosticSeverity.Error,
+                    range: {
+                        start: {
+                            line: pos.$p[0],
+                            character: pos.$p[1],
+                        },
+                        end: {
+                            line: pos.$p[2],
+                            character: pos.$p[3],
+                        },
+                    },
+                    message: `Multiple primary keys defined in view "${view.$name}": ${pkNames}. A view can only have one primary key.`,
+                    source: "lookml-lsp",
+                    code: DiagnosticCode.VIEW_MULTIPLE_PRIMARY_KEYS,
+                });
+            }
+        }
+
+        return diagnostics;
+    }
+
     // Then in the validation method:
     protected validateProperties(document: TextDocument): Diagnostic[] {
         let diagnostics: Diagnostic[] = [];
@@ -567,6 +623,13 @@ export class DiagnosticsProvider {
                         source: "lookml-lsp",
                     });
                 }
+
+                diagnostics.push(
+                    ...this.validateMultiplePrimaryKeys(
+                        view,
+                        viewDetails,
+                    ),
+                );
 
                 if (view.drill_fields) {
                     diagnostics.push(


### PR DESCRIPTION
## Summary

- Adds diagnostic code `VIEW_MULTIPLE_PRIMARY_KEYS` (20005) that flags views with more than one `primary_key: yes` dimension
- Checks all dimensions including those inherited via `extends`, but only reports errors on locally-defined primary keys (so the error appears in the file the developer is editing)
- Includes 4 test cases: two PKs in same view, single PK (no error), no PK (no error), and inherited PK conflict via extends

## Test plan

- [x] `npx jest multiple_primary_keys` — 4/4 pass
- [x] Full test suite — all 64 tests pass (1 pre-existing unrelated failure in `lookml-validator` module resolution)

Closes #131

Made with [Cursor](https://cursor.com)