### PR TITLE
fix: resolve false-positive field-not-found for extends, dimension_group timeframes, and $ in SQL strings

### DIFF
--- a/server/src/__tests__/sql_string_dollar/index.test.ts
+++ b/server/src/__tests__/sql_string_dollar/index.test.ts
@@ -1,0 +1,65 @@
+import * as fs from "fs";
+import * as path from "path";
+import { TextDocument } from "vscode-languageserver-textdocument";
+import { Diagnostic } from "vscode-languageserver/node";
+import { WorkspaceModel } from "../../models/workspace";
+import { DiagnosticCode, DiagnosticsProvider } from "../../providers/diagnostics";
+import { createMockConnection, getDiagnosticsForView } from "../utils";
+
+describe("Dollar sign in SQL string literals", () => {
+    let workspaceModel: WorkspaceModel;
+    let diagnosticsProvider: DiagnosticsProvider;
+    let mockConnection: any;
+    let sharedDiagnostics: Diagnostic[];
+
+    beforeAll(async () => {
+        mockConnection = createMockConnection();
+        workspaceModel = new WorkspaceModel({ connection: mockConnection });
+        diagnosticsProvider = new DiagnosticsProvider(workspaceModel);
+
+        const examplePath = path.join(
+            __dirname,
+            "lkml",
+            "sql_string_dollar.model.lkml",
+        );
+
+        const content = fs.readFileSync(examplePath, "utf8");
+        const document = TextDocument.create(
+            `file://${examplePath}`,
+            "lookml",
+            1,
+            content,
+        );
+
+        await workspaceModel.parseFiles({
+            source: examplePath,
+            reset: true,
+        });
+
+        sharedDiagnostics = diagnosticsProvider.validateDocument(document);
+    });
+
+    test("should NOT flag $ inside BigQuery regex string literals as malformed references", () => {
+        const errors = getDiagnosticsForView(
+            workspaceModel,
+            sharedDiagnostics,
+            "dollar_in_string",
+        );
+        const malformedErrors = errors.filter(
+            (d) => d.code === DiagnosticCode.VIEW_REF_FIELD_IN_SQL,
+        );
+        expect(malformedErrors).toHaveLength(0);
+    });
+
+    test("should still flag truly malformed references like $foo", () => {
+        const errors = getDiagnosticsForView(
+            workspaceModel,
+            sharedDiagnostics,
+            "truly_malformed",
+        );
+        const malformedErrors = errors.filter(
+            (d) => d.code === DiagnosticCode.VIEW_REF_FIELD_IN_SQL,
+        );
+        expect(malformedErrors.length).toBeGreaterThan(0);
+    });
+});

--- a/server/src/__tests__/sql_string_dollar/lkml/sql_string_dollar.model.lkml
+++ b/server/src/__tests__/sql_string_dollar/lkml/sql_string_dollar.model.lkml
@@ -1,0 +1,36 @@
+connection: "test"
+
+include: "*.view.lkml"
+
+view: dollar_in_string {
+  sql_table_name: `my_table` ;;
+
+  dimension: raw_name {
+    type: string
+    sql: ${TABLE}.raw_name ;;
+  }
+
+  dimension: cleaned_name {
+    type: string
+    sql: REGEXP_REPLACE(${raw_name}, r' - [^-]+$', '') ;;
+  }
+
+  dimension: extracted_suffix {
+    type: string
+    sql: INITCAP(REGEXP_EXTRACT(${raw_name}, r' - ([^-]+)$')) ;;
+  }
+
+  dimension: with_dollar_literal {
+    type: string
+    sql: CONCAT(${raw_name}, ' costs $100') ;;
+  }
+}
+
+view: truly_malformed {
+  sql_table_name: `my_table` ;;
+
+  dimension: bad_ref {
+    type: string
+    sql: $foo ;;
+  }
+}

--- a/server/src/providers/diagnostics.ts
+++ b/server/src/providers/diagnostics.ts
@@ -86,6 +86,46 @@ export class DiagnosticsProvider {
     }
 
     /**
+     * Check whether a field (dimension, measure, or dimension_group timeframe)
+     * exists in the given view, including all fields inherited via `extends:`.
+     *
+     * Uses `getViewFields()` to resolve extends recursively, then iterates
+     * every dimension_group's timeframes to match generated field names such as
+     * `transaction_date_raw` or `transaction_date_month_name`.
+     *
+     * The previous approach split `fieldName` on `_` and used the last segment
+     * as the timeframe, which failed for multi-word timeframes like `month_name`
+     * or `day_of_week`.  This helper iterates all declared timeframes and checks
+     * for an exact `${groupName}_${timeframe}` match.
+     */
+    private fieldExistsInView(viewName: string, fieldName: string): boolean {
+        const fields = this.workspaceModel.getViewFields(viewName);
+
+        if (fields.dimension?.[fieldName] || fields.measure?.[fieldName]) {
+            return true;
+        }
+        if (fields.dimension_group?.[fieldName]) return true;
+
+        // Generated dimension_group timeframe fields (e.g. transaction_date_raw,
+        // transaction_date_month_name).  Iterate all groups and their declared
+        // timeframes so that multi-word timeframes with underscores are handled.
+        for (const [dimGroupName, dimGroup] of Object.entries(
+            fields.dimension_group,
+        )) {
+            if (!dimGroup) continue;
+            const timeframes: string[] = (dimGroup as any).timeframes ?? [
+                "time",
+                "date",
+            ];
+            for (const timeframe of timeframes) {
+                if (fieldName === `${dimGroupName}_${timeframe}`) return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
      * Validate a document and return diagnostics
      */
     public validateDocument(document: TextDocument): Diagnostic[] {
@@ -277,13 +317,11 @@ export class DiagnosticsProvider {
                     continue;
                 }
 
-                const fields = this.workspaceModel.getViewFields(
-                    viewDetails.view.$name!,
-                );
                 if (
-                    !fields.dimension?.[fieldName] &&
-                    !fields.measure?.[fieldName] &&
-                    !fields.dimension_group?.[fieldName] &&
+                    !this.fieldExistsInView(
+                        viewDetails.view.$name!,
+                        fieldName,
+                    ) &&
                     fieldName !== "SQL_TABLE_NAME"
                 ) {
                     diagnostics.push({
@@ -297,26 +335,17 @@ export class DiagnosticsProvider {
                 const fieldName = ref;
                 refViewName = currentViewName;
                 refFieldName = fieldName;
-                const viewDetails =
-                    this.workspaceModel.getView(currentViewName);
-                if (viewDetails) {
-                    const fields = this.workspaceModel.getViewFields(
-                        viewDetails.view.$name!,
-                    );
-                    if (
-                        !fields.dimension?.[fieldName] &&
-                        !fields.measure?.[fieldName] &&
-                        !fields.dimension_group?.[fieldName] &&
-                        fieldName !== "TABLE" &&
-                        fieldName !== "SQL_TABLE_NAME"
-                    ) {
-                        diagnostics.push({
-                            severity: DiagnosticSeverity.Error,
-                            range,
-                            message: `Could not find a field named "${ref}"`,
-                            code: DiagnosticCode.VIEW_REF_FIELD_NOT_FOUND,
-                        });
-                    }
+                if (
+                    !this.fieldExistsInView(currentViewName, fieldName) &&
+                    fieldName !== "TABLE" &&
+                    fieldName !== "SQL_TABLE_NAME"
+                ) {
+                    diagnostics.push({
+                        severity: DiagnosticSeverity.Error,
+                        range,
+                        message: `Could not find a field named "${ref}"`,
+                        code: DiagnosticCode.VIEW_REF_FIELD_NOT_FOUND,
+                    });
                 }
             }
 
@@ -341,7 +370,11 @@ export class DiagnosticsProvider {
         }
 
         // ❌ Detect malformed references (e.g. $foo, $foo}, ${bar)
-        while ((match = invalidRefPattern.exec(sql)) !== null) {
+        // Strip single-quoted string literals first so that $ inside SQL
+        // strings (e.g. BigQuery regex anchors like r'[^-]+$') are not
+        // falsely flagged as malformed LookML references.
+        const sqlWithoutStringLiterals = sql.replace(/'[^']*'/g, "''");
+        while ((match = invalidRefPattern.exec(sqlWithoutStringLiterals)) !== null) {
             diagnostics.push({
                 severity: DiagnosticSeverity.Error,
                 range,
@@ -448,38 +481,7 @@ export class DiagnosticsProvider {
             }
 
             const fields = this.workspaceModel.getViewFields(targetedViewName!);
-            const viewDimensions = fields.dimension;
-            const viewMeasures = fields.measure;
-            const viewDimensionGroups = fields.dimension_group;
-
-            if (
-                !viewDimensions?.[fieldName] &&
-                !viewMeasures?.[fieldName] &&
-                !viewDimensionGroups?.[fieldName]
-            ) {
-                if (fieldName.includes("_")) {
-                    const fieldSplit = fieldName.split("_");
-                    const groupName = fieldSplit.pop();
-                    if (!groupName) {
-                        throw new Error(
-                            `No group name found for field ${fieldName}`,
-                        );
-                    }
-                    const dimensionGroupName = fieldSplit.join("_");
-                    const dimensionGroup =
-                        viewDimensionGroups?.[dimensionGroupName];
-                    const timeframes = dimensionGroup?.timeframes ?? [
-                        "time",
-                        "date",
-                    ];
-                    if (
-                        viewDimensionGroups?.[dimensionGroupName] &&
-                        timeframes.includes(groupName)
-                    ) {
-                        continue;
-                    }
-                }
-
+            if (!this.fieldExistsInView(targetedViewName!, fieldName)) {
                 diagnostics.push({
                     severity: DiagnosticSeverity.Error,
                     message: `Field "${fieldName}" not found in view "${targetedViewDetails.view.$name}"`,
@@ -790,50 +792,12 @@ export class DiagnosticsProvider {
                                 });
                                 continue;
                             }
-                            const viewDimensions =
-                                targetedViewDetails.view.dimension;
-                            const viewMeasures =
-                                targetedViewDetails.view.measure;
-                            const viewDimensionGroups =
-                                targetedViewDetails.view.dimension_group;
-
                             if (
-                                !viewDimensions?.[fieldName] &&
-                                !viewMeasures?.[fieldName] &&
-                                !viewDimensionGroups?.[fieldName]
+                                !this.fieldExistsInView(
+                                    targetedViewName!,
+                                    fieldName,
+                                )
                             ) {
-                                if (fieldName.includes("_")) {
-                                    const fieldSplit = fieldName.split("_");
-                                    const groupName = fieldSplit.pop();
-
-                                    if (!groupName) {
-                                        throw new Error(
-                                            `No group name found for field ${fieldName}`,
-                                        );
-                                    }
-
-                                    const dimensionGroupName =
-                                        fieldSplit.join("_");
-                                    const dimensionGroup =
-                                        viewDimensionGroups?.[
-                                            dimensionGroupName
-                                        ];
-
-                                    const timeframes =
-                                        dimensionGroup?.timeframes ?? [
-                                            "time",
-                                            "date",
-                                        ];
-                                    if (
-                                        viewDimensionGroups?.[
-                                            dimensionGroupName
-                                        ] &&
-                                        timeframes.includes(groupName)
-                                    ) {
-                                        continue;
-                                    }
-                                }
-
                                 diagnostics.push({
                                     severity: DiagnosticSeverity.Error,
                                     message: `Field "${fieldName}" not found in view "${targetedViewName}"`,

--- a/server/src/providers/diagnostics.ts
+++ b/server/src/providers/diagnostics.ts
@@ -18,6 +18,7 @@ import { URI } from "vscode-uri";
 import { ZodError, ZodIssue } from "zod";
 import { WorkspaceModel } from "../models/workspace";
 import { VALID_TIMEFRAMES } from "../schemas/constants";
+import { DIMENSION_GROUP_DEFAULT_TIMEFRAMES } from "../schemas/defaults";
 import { exploreSchema, LookMLView } from "../schemas/lookml";
 import { ensureMinRangeLength } from "../utils/range";
 
@@ -113,10 +114,8 @@ export class DiagnosticsProvider {
             fields.dimension_group,
         )) {
             if (!dimGroup) continue;
-            const timeframes: string[] = (dimGroup as any).timeframes ?? [
-                "time",
-                "date",
-            ];
+            const timeframes: string[] =
+                (dimGroup as any).timeframes ?? DIMENSION_GROUP_DEFAULT_TIMEFRAMES;
             for (const timeframe of timeframes) {
                 if (fieldName === `${dimGroupName}_${timeframe}`) return true;
             }


### PR DESCRIPTION
## Summary

- **`extends:` field inheritance** — adds a `fieldExistsInView()` helper that delegates to the existing `getViewFields()` (which already merges extended views) so that fields inherited from a base view are no longer falsely flagged as "not found" in SQL references, `drill_fields`, and `set` arrays.
- **Multi-word dimension_group timeframes** — replaces the `split('_').pop()` timeframe-matching logic with full iteration over all declared timeframes, fixing false positives for fields like `transaction_date_month_name` or `transaction_date_raw`.
- **`$` in single-quoted SQL strings** — strips string literals before running the `invalidRefPattern` scan so that BigQuery regex anchors like `r'[^-]+$'` no longer trigger "Malformed LookML reference".

New test suite: `sql_string_dollar`. Existing `dimension_group` and `extends_field_resolution` suites cover the other two fixes. All tests pass.

Closes #133

Made with [Cursor](https://cursor.com)